### PR TITLE
Static constructor method (`StringHelpers::from()`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,3 +114,8 @@ All notable changes to `string-helpers` will be documented in this file
 
 ## 1.2.3 - 2021-08-04
 - bump min sfneal/array-helpers version to v3.0 & refactor use
+
+
+## 1.2.4 - 2022-11-20
+- add use of GitHub actions for composer installations & PHPunit tests
+- add `StringHelpers::from()` static constructor method for improved syntax

--- a/src/StringHelpers.php
+++ b/src/StringHelpers.php
@@ -25,6 +25,11 @@ class StringHelpers
         $this->string = $string;
     }
 
+    public static function from(string $string): self
+    {
+        return new self($string);
+    }
+
     /**
      * Sanitize a file name to remove illegal chars.
      *

--- a/tests/Feature/StringHelpersTest.php
+++ b/tests/Feature/StringHelpersTest.php
@@ -21,6 +21,17 @@ class StringHelpersTest extends TestCase
     }
 
     /** @test */
+    public function sanitizeFileNameWithStaticConstructor()
+    {
+        $expected = 'random_string_name';
+        $string = StringHelpers::from('random.string.name')->sanitizeFileName();
+
+        $this->assertStringNotContainsString('.', $string);
+        $this->assertStringContainsString('_', $string);
+        $this->assertSame($expected, $string);
+    }
+
+    /** @test */
     public function truncate()
     {
         $string = (new StringHelpers(randomPassword(20)))->truncate(10, '');


### PR DESCRIPTION
- add `StringHelpers::from()` static constructor method for improved syntax